### PR TITLE
fix: enforce push-first policy for reviewer agent

### DIFF
--- a/prompts/reviewer-system.md
+++ b/prompts/reviewer-system.md
@@ -12,6 +12,8 @@ You are the **reviewer** in a Ralph loop — an iterative work/review/ship cycle
 
 Examine the code changes made by the worker. **Run tests, linters, and build commands** to independently verify the code works — do not trust the worker's claims. If the project has a test suite, run it. If there's a linter, run it.
 
+**IMPORTANT: Do not preemptively reject changes based on assumed permission issues.** If workflow files were modified, this is NOT automatically a reason to REVISE. The action may be using a PAT token which has full repository permissions. Always attempt to push first (see "When Done" section) and only reject if the push actually fails with a permission error.
+
 Evaluate against these criteria:
 
 ### SHIP Criteria (all must be true)
@@ -55,7 +57,12 @@ Before pushing, ensure the branch is clean:
 3. **Perform branch cleanup** (see section above)
 4. **Push the branch and create or update the pull request:**
    - Read `.ralph/pr-info.txt` for context (repo, branch, issue_title, pr_number, merge_strategy, default_branch)
-   - **Push the branch first:** `git push origin <branch>` (required before PR creation)
+   - **CRITICAL: ALWAYS push the branch first:** `git push origin <branch>`
+     - **You MUST attempt to push, even if workflow files were modified**
+     - Do NOT assume workflow changes will fail due to permissions
+     - PAT tokens (like `GH_PAT_TOKEN`) have user-level repository permissions and bypass the `workflows: write` restriction that applies only to the default `GITHUB_TOKEN`
+     - **Only if the push actually fails with a permission error should you question workflow changes**
+     - If push succeeds, continue with PR creation below
    - Generate a PR title using conventional commits format: `<type>: <description>`
      - Infer the type from changes: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `style`, `perf`, `build`, `ci`, `revert`
      - Description must be lowercase and start with a verb

--- a/prompts/reviewer-system.md
+++ b/prompts/reviewer-system.md
@@ -60,7 +60,7 @@ Before pushing, ensure the branch is clean:
    - **CRITICAL: ALWAYS push the branch first:** `git push origin <branch>`
      - **You MUST attempt to push, even if workflow files were modified**
      - Do NOT assume workflow changes will fail due to permissions
-     - PAT tokens (like `GH_PAT_TOKEN`) have user-level repository permissions and bypass the `workflows: write` restriction that applies only to the default `GITHUB_TOKEN`
+     - PAT tokens (like `GH_PAT_TOKEN`) have user-level repository permissions and are not subject to the workflow file modification restriction that applies to the default `GITHUB_TOKEN`
      - **Only if the push actually fails with a permission error should you question workflow changes**
      - If push succeeds, continue with PR creation below
    - Generate a PR title using conventional commits format: `<type>: <description>`


### PR DESCRIPTION
Closes #35

**Status**: SHIP after 2 iteration(s)

## Work Summary

### Root Cause
The reviewer agent in run #22078670669 (issue #33) incorrectly rejected workflow file changes without attempting to push first. It assumed the GitHub App lacked `workflows: write` permission, but this was a false assumption because the dogfood workflow uses a PAT token (`GH_PAT_TOKEN`), not the default `GITHUB_TOKEN`. PAT tokens have user-level repository permissions and bypass the `workflows: write` restriction entirely.

### Changes Made
Updated `prompts/reviewer-system.md` with three key improvements:

1. **Early warning in Review Process section (line 15)**: Added explicit guidance that workflow file modifications should NOT be preemptively rejected based on assumed permission issues. The reviewer must always attempt to push first.

2. **Emphasized push-first requirement (lines 60-65)**: Changed "Push the branch first:" to "CRITICAL: ALWAYS push the branch first:" with detailed bullet points explaining:
   - Push MUST be attempted even if workflow files were modified
   - Do NOT assume workflow changes will fail
   - PAT tokens bypass `workflows: write` restrictions
   - Only actual push failures should trigger rejection of workflow changes

3. **Added context about PAT tokens**: Documented that PAT tokens like `GH_PAT_TOKEN` have user-level repository permissions, which is why they can modify workflow files regardless of the `permissions:` block in the workflow.

### Files Modified
- `prompts/reviewer-system.md` (8 lines added, 1 line modified)

### Testing
Changes are to documentation/prompts only. No tests need to run. The fix prevents the reviewer agent from making unfounded assumptions about permissions in future runs.

### Outcome
The reviewer agent will now be forced to attempt pushing before rejecting workflow changes, which should prevent the issue seen in run #22078670669 from recurring.

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_