### PR TITLE
docs: add ralph loop visualization gif to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ When you label an issue, Ralph:
 4. If the reviewer says **REVISE**, loops back to step 2 with feedback
 5. If the reviewer says **SHIP**, pushes the branch and opens a PR
 
+![Ralph Loop](https://i.giphy.com/3wr2cnwlghNomDeN9W.webp)
+
 ## Quick Start
 
 1. Add `ANTHROPIC_API_KEY` as a [repository secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions)


### PR DESCRIPTION
Closes #40

**Status:** ✅ SHIP (iteration 1)

## Work Summary
- Added the Ralph loop visualization GIF (https://i.giphy.com/3wr2cnwlghNomDeN9W.webp) to README.md
- Placed the image immediately after the 5-step explanation of how Ralph works, before the "Quick Start" section
- This location provides visual context for the iterative work/review/ship cycle described in the list above it

## Review Result
✅ **Approved** - All task requirements met. The image was added in the most relevant location with proper markdown formatting and conventional commit message.

---
_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_