### PR TITLE
fix: use auto-detected base branch as fallback for default_branch in pr-info.txt

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,7 +145,7 @@ state_write_iteration "0"
   echo "branch=${BRANCH_NAME}"
   echo "issue_title=${ISSUE_TITLE}"
   echo "merge_strategy=${INPUT_MERGE_STRATEGY:-pr}"
-  echo "default_branch=${INPUT_DEFAULT_BRANCH:-}"
+  echo "default_branch=${INPUT_DEFAULT_BRANCH:-${BASE_BRANCH}}"
   # Check if a PR already exists for this branch
   existing_pr_number="$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${BRANCH_NAME}" --json number --jq '.[0].number' 2>/dev/null || echo "")"
   if [[ -n "${existing_pr_number}" ]]; then


### PR DESCRIPTION
Closes #54

## Summary
- Fixed `entrypoint.sh` to use the auto-detected `BASE_BRANCH` as a fallback when writing `default_branch` to `pr-info.txt`, instead of leaving it empty
- Changed `${INPUT_DEFAULT_BRANCH:-}` to `${INPUT_DEFAULT_BRANCH:-${BASE_BRANCH}}` on line 148
- This prevents the reviewer agent from needing to re-detect the default branch during squash-merge operations

## Test plan
- [x] All 6 existing tests pass (unit + integration)
- [x] Verified `BASE_BRANCH` is always defined before the pr-info.txt write block
- [x] Change is a single-line parameter expansion fix with no structural impact

✅ **SHIP** — Iteration 1

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_