### PR TITLE
fix: make error messages reachable in worker.sh and reviewer.sh

### DIFF
--- a/scripts/reviewer.sh
+++ b/scripts/reviewer.sh
@@ -50,9 +50,8 @@ if [[ "${RALPH_VERBOSE:-false}" == "true" ]]; then
 fi
 
 # Invoke Claude CLI in print mode with the reviewer system prompt
-claude "${cli_args[@]}" "${prompt}"
-
-reviewer_exit=$?
+reviewer_exit=0
+claude "${cli_args[@]}" "${prompt}" || reviewer_exit=$?
 
 if [[ ${reviewer_exit} -ne 0 ]]; then
   echo "ERROR: Reviewer Claude CLI exited with code ${reviewer_exit}"

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -54,9 +54,8 @@ if [[ "${RALPH_VERBOSE:-false}" == "true" ]]; then
 fi
 
 # Invoke Claude CLI in print mode with the worker system prompt
-claude "${cli_args[@]}" "${prompt}"
-
-worker_exit=$?
+worker_exit=0
+claude "${cli_args[@]}" "${prompt}" || worker_exit=$?
 
 if [[ ${worker_exit} -ne 0 ]]; then
   echo "ERROR: Worker Claude CLI exited with code ${worker_exit}"


### PR DESCRIPTION
Closes #51

## Status
✅ **SHIP** — Iteration 1

## Work Summary
Fixed dead code in `scripts/worker.sh` and `scripts/reviewer.sh` where error messages after the `claude` CLI invocation were unreachable due to `set -euo pipefail`. 

The `claude` command was called directly, so if it exited non-zero, `set -e` would terminate the script immediately — the `$?` capture and human-readable error messages were never reached.

**Fix:** Replaced the pattern in both files with:
```bash
worker_exit=0
claude "${cli_args[@]}" "${prompt}" || worker_exit=$?
```

The `|| worker_exit=$?` prevents `set -e` from killing the script, captures the actual exit code, and lets the error message print before exiting.

### Files Modified
- `scripts/worker.sh` — Fixed dead code pattern
- `scripts/reviewer.sh` — Fixed dead code pattern

### Verification
- `shellcheck --severity=warning` passes clean on both files
- All 6 tests pass, including `test/integration/test-error-handling.sh` which now shows the error message being printed

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_