### PR TITLE
chore: add .ralph/ to .gitignore to prevent accidental commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.log
 .env
+.ralph/


### PR DESCRIPTION
Closes #64

## Status
✅ **SHIP** — Iteration 1

## Work Summary
Added `.ralph/` to `.gitignore` to prevent accidental commits of the Ralph state directory. This is a defense-in-depth improvement that eliminates an entire class of potential issues with a one-line change.

### Changes
- `.gitignore` — added `.ralph/` entry after the existing `.env` line

### Verification
- `git check-ignore .ralph/` confirms the directory is now properly ignored
- All 8 tests pass (unit + integration)
- No shell scripts were modified, so shellcheck is not applicable

## Review Notes
The implementation is clean and correct. The commit message follows conventional commits format. The change precisely matches the task requirements — nothing more, nothing less.

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_