### PR TITLE
fix: replace heredoc with printf in state_write_task to prevent content injection

### DIFF
--- a/scripts/state.sh
+++ b/scripts/state.sh
@@ -15,26 +15,16 @@ state_init() {
 
 # Write the task description from the issue
 # Args: $1 = issue title, $2 = issue body, $3 = issue comments (optional)
+# Uses printf instead of heredocs to avoid injection when content contains delimiter strings
 state_write_task() {
   local title="$1"
   local body="$2"
   local comments="${3:-}"
-  cat > "${RALPH_DIR}/task.md" <<EOF
-# ${title}
-
-${body}
-EOF
+  printf '# %s\n\n%s\n' "${title}" "${body}" > "${RALPH_DIR}/task.md"
 
   # Append comments if provided
   if [[ -n "${comments}" ]]; then
-    cat >> "${RALPH_DIR}/task.md" <<EOF
-
----
-
-# Issue Comments
-
-${comments}
-EOF
+    printf '\n---\n\n# Issue Comments\n\n%s\n' "${comments}" >> "${RALPH_DIR}/task.md"
   fi
 }
 

--- a/test/unit/test-state.sh
+++ b/test/unit/test-state.sh
@@ -283,6 +283,86 @@ test_state_write_read_final_status() {
   echo "PASS: state_write_final_status and state_read_final_status work correctly"
 }
 
+test_state_write_task_with_delimiter_in_content() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cd "${tmpdir}"
+  state_init
+
+  # Body contains "EOF" on its own line, which would break a heredoc-based implementation
+  local body
+  body=$'Here is a code snippet:\n```\nEOF\n```\nEnd of snippet.'
+  state_write_task "Delimiter Test" "${body}"
+
+  if [[ ! -f ".ralph/task.md" ]]; then
+    echo "FAIL: task.md should be created"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "# Delimiter Test" .ralph/task.md; then
+    echo "FAIL: task.md should contain the title"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "^EOF$" .ralph/task.md; then
+    echo "FAIL: task.md should contain literal EOF line from body"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "End of snippet" .ralph/task.md; then
+    echo "FAIL: task.md should contain content after the EOF line"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  cd - > /dev/null
+  rm -rf "${tmpdir}"
+  echo "PASS: state_write_task handles delimiter strings in content"
+}
+
+test_state_write_task_with_delimiter_in_comments() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cd "${tmpdir}"
+  state_init
+
+  local comments
+  comments=$'## Comment by @user1\n\nEOF\nMore text after EOF'
+  state_write_task "Comment Delimiter Test" "Normal body" "${comments}"
+
+  if ! grep -q "# Comment Delimiter Test" .ralph/task.md; then
+    echo "FAIL: task.md should contain the title"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "Issue Comments" .ralph/task.md; then
+    echo "FAIL: task.md should contain issue comments section"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "More text after EOF" .ralph/task.md; then
+    echo "FAIL: task.md should contain content after EOF in comments"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  cd - > /dev/null
+  rm -rf "${tmpdir}"
+  echo "PASS: state_write_task handles delimiter strings in comments"
+}
+
 # Run all tests
 main() {
   local failed=0
@@ -293,6 +373,8 @@ main() {
   test_state_review_result_normalization || failed=$((failed + 1))
   test_state_write_read_task || failed=$((failed + 1))
   test_state_write_task_with_comments || failed=$((failed + 1))
+  test_state_write_task_with_delimiter_in_content || failed=$((failed + 1))
+  test_state_write_task_with_delimiter_in_comments || failed=$((failed + 1))
   test_state_write_read_issue_number || failed=$((failed + 1))
   test_state_write_read_work_summary || failed=$((failed + 1))
   test_state_write_read_final_status || failed=$((failed + 1))


### PR DESCRIPTION
Closes #63

## Status
✅ **SHIP** — Iteration 1

## Work Summary
Replaced the two `cat <<EOF` heredoc writes in `state_write_task` (scripts/state.sh) with `printf` statements. The old code used unquoted heredocs with user-controlled content (`$title`, `$body`, `$comments`) interpolated inside. If any of those variables contained the literal string `EOF` on its own line, bash would terminate the heredoc prematurely — causing mangled task files or shell syntax errors. The new `printf`-based approach is completely immune to delimiter injection.

Added two new unit tests in `test/unit/test-state.sh`:
- `test_state_write_task_with_delimiter_in_content`: Verifies that an issue body containing `EOF` on its own line is written correctly
- `test_state_write_task_with_delimiter_in_comments`: Verifies the same for comments containing `EOF`

All 8 tests pass.

## Review
No issues found. The fix is minimal, focused, and preserves the exact output format. Commit message follows conventional commits format.

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_