### PR TITLE
feat: comment in the pull request

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -7,6 +7,10 @@ on:
     types: [created]
   pull_request:
     types: [labeled]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
   contents: write
@@ -36,11 +40,13 @@ jobs:
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ralph') ||
       (github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'ralph')) ||
-      (github.event.action == 'created' && contains(github.event.issue.labels.*.name, 'ralph') && github.event.comment.user.type != 'Bot' && !contains(github.event.comment.body, '<!-- ralph-comment-') && !github.event.issue.pull_request)
+      (github.event.action == 'created' && contains(github.event.issue.labels.*.name, 'ralph') && github.event.comment.user.type != 'Bot' && !contains(github.event.comment.body, '<!-- ralph-comment-') && !github.event.issue.pull_request) ||
+      (github.event_name == 'pull_request_review_comment' && github.event.action == 'created' && github.event.comment.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'ralph/issue-')) ||
+      (github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'ralph/issue-'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: ralph-${{ github.event.issue.number }}
+      group: ralph-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,12 +55,35 @@ if ! command -v jq &> /dev/null; then
   exit 1
 fi
 
-# Check issue number from event file
-TEMP_ISSUE_NUMBER="$(jq -r '.issue.number // empty' "${GITHUB_EVENT_PATH}" 2>/dev/null || echo "")"
-if [[ -z "${TEMP_ISSUE_NUMBER}" ]]; then
-  echo "❌ Error: Event file does not contain a valid issue number"
-  echo "   Fix: Ensure this action is triggered by an issue event"
-  exit 1
+# Detect whether this is a PR review event or a regular issue event.
+# Use GITHUB_EVENT_NAME (set by GitHub Actions) for unambiguous detection.
+# Checking .pull_request.number would be ambiguous because pull_request: [labeled]
+# events also carry that field.
+PR_REVIEW_EVENT=false
+PR_NUMBER=""
+PR_BRANCH=""
+TEMP_ISSUE_NUMBER=""
+if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request_review_comment" || \
+      "${GITHUB_EVENT_NAME:-}" == "pull_request_review" ]]; then
+  PR_REVIEW_EVENT=true
+  PR_NUMBER="$(jq -r '.pull_request.number' "${GITHUB_EVENT_PATH}")"
+  PR_BRANCH="$(jq -r '.pull_request.head.ref // ""' "${GITHUB_EVENT_PATH}")"
+  # Extract issue number from the ralph branch name (pattern: ralph/issue-NNN)
+  if [[ "${PR_BRANCH}" =~ ralph/issue-([0-9]+) ]]; then
+    TEMP_ISSUE_NUMBER="${BASH_REMATCH[1]}"
+  fi
+  if [[ -z "${TEMP_ISSUE_NUMBER}" ]]; then
+    echo "❌ Error: Cannot determine issue number from PR branch: ${PR_BRANCH}"
+    echo "   Fix: The PR branch must follow the pattern 'ralph/issue-NNN'"
+    exit 1
+  fi
+else
+  TEMP_ISSUE_NUMBER="$(jq -r '.issue.number // empty' "${GITHUB_EVENT_PATH}" 2>/dev/null || echo "")"
+  if [[ -z "${TEMP_ISSUE_NUMBER}" ]]; then
+    echo "❌ Error: Event file does not contain a valid issue number"
+    echo "   Fix: Ensure this action is triggered by an issue event"
+    exit 1
+  fi
 fi
 
 if ! [[ "${TEMP_ISSUE_NUMBER}" =~ ^[0-9]+$ ]]; then
@@ -71,12 +94,25 @@ fi
 
 # --- Extract issue data from GitHub event ---
 EVENT_PATH="${GITHUB_EVENT_PATH}"
-ISSUE_NUMBER="$(jq -r '.issue.number' "${EVENT_PATH}")"
-ISSUE_TITLE="$(jq -r '.issue.title' "${EVENT_PATH}")"
-ISSUE_BODY="$(jq -r '.issue.body // ""' "${EVENT_PATH}")"
-IS_PULL_REQUEST="$(jq -r '.issue.pull_request // empty' "${EVENT_PATH}")"
 EVENT_ACTION="$(jq -r '.action // ""' "${EVENT_PATH}")"
-EVENT_COMMENT_ID="$(jq -r '.comment.id // ""' "${EVENT_PATH}")"
+
+if [[ "${PR_REVIEW_EVENT}" == "true" ]]; then
+  # PR review event: fetch issue data from GitHub API using the issue number
+  # extracted from the branch name (the issue JSON is not present in this event type)
+  echo "🔗 PR review event: PR #${PR_NUMBER} on branch ${PR_BRANCH}"
+  echo "📋 Fetching data for issue #${TEMP_ISSUE_NUMBER}..."
+  ISSUE_NUMBER="${TEMP_ISSUE_NUMBER}"
+  ISSUE_TITLE="$(gh issue view "${ISSUE_NUMBER}" --json title --jq '.title' 2>/dev/null || echo "Issue #${ISSUE_NUMBER}")"
+  ISSUE_BODY="$(gh issue view "${ISSUE_NUMBER}" --json body --jq '.body // ""' 2>/dev/null || echo "")"
+  IS_PULL_REQUEST=""
+  EVENT_COMMENT_ID="$(jq -r '.comment.id // ""' "${EVENT_PATH}")"
+else
+  ISSUE_NUMBER="$(jq -r '.issue.number' "${EVENT_PATH}")"
+  ISSUE_TITLE="$(jq -r '.issue.title' "${EVENT_PATH}")"
+  ISSUE_BODY="$(jq -r '.issue.body // ""' "${EVENT_PATH}")"
+  IS_PULL_REQUEST="$(jq -r '.issue.pull_request // empty' "${EVENT_PATH}")"
+  EVENT_COMMENT_ID="$(jq -r '.comment.id // ""' "${EVENT_PATH}")"
+fi
 
 # --- Fetch all issue comments to compound the context ---
 # Comments provide additional context for agents. New comments on a labeled issue
@@ -95,7 +131,38 @@ else
   echo "⚠️  gh command not available, skipping comment fetch"
 fi
 
-# --- Reject pull requests ---
+# --- Fetch PR review comments when triggered by a PR review event ---
+# Inline code comments and overall review bodies are appended to the task context
+# so the worker agent can address the specific feedback from the PR reviewer.
+if [[ "${PR_REVIEW_EVENT}" == "true" ]] && command -v gh &> /dev/null; then
+  echo "💬 Fetching PR #${PR_NUMBER} review comments..."
+  PR_INLINE_COMMENTS="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments" \
+    --jq '.[] | "### Inline comment by @\(.user.login) on `\(.path)`:\(.line // .original_line // "?"):\n\n\(.body)\n"' \
+    2>/dev/null || echo "")"
+  PR_REVIEWS="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+    --jq '.[] | select(.body != null and .body != "") | "### Review by @\(.user.login) (\(.state)):\n\n\(.body)\n"' \
+    2>/dev/null || echo "")"
+  if [[ -n "${PR_INLINE_COMMENTS}" || -n "${PR_REVIEWS}" ]]; then
+    PR_REVIEW_CONTEXT="# PR Review Feedback (PR #${PR_NUMBER})"$'\n'
+    PR_REVIEW_CONTEXT+="This run was triggered by a PR review comment on PR #${PR_NUMBER} (branch: ${PR_BRANCH}). Address all reviewer feedback below."$'\n'
+    if [[ -n "${PR_INLINE_COMMENTS}" ]]; then
+      PR_REVIEW_CONTEXT+=$'\n## Inline Code Comments\n\n'"${PR_INLINE_COMMENTS}"
+    fi
+    if [[ -n "${PR_REVIEWS}" ]]; then
+      PR_REVIEW_CONTEXT+=$'\n## Overall Reviews\n\n'"${PR_REVIEWS}"
+    fi
+    echo "✅ Found PR review context for PR #${PR_NUMBER}"
+    if [[ -n "${ISSUE_COMMENTS}" ]]; then
+      ISSUE_COMMENTS+=$'\n\n'"${PR_REVIEW_CONTEXT}"
+    else
+      ISSUE_COMMENTS="${PR_REVIEW_CONTEXT}"
+    fi
+  else
+    echo "ℹ️  No PR review comments found for PR #${PR_NUMBER}"
+  fi
+fi
+
+# --- Reject pull requests labeled with ralph (not PR review events) ---
 if [[ -n "${IS_PULL_REQUEST}" ]]; then
   echo "⚠️  Ralph was triggered on a pull request (#${ISSUE_NUMBER}), not an issue. Skipping."
   gh issue comment "${ISSUE_NUMBER}" --body "🤖 **Ralph** can only work on issues, not pull requests. Please label an issue instead." || true

--- a/examples/ralph-workflow.yml
+++ b/examples/ralph-workflow.yml
@@ -7,6 +7,10 @@ on:
     types: [created]
   pull_request:
     types: [labeled]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
   contents: write
@@ -36,11 +40,13 @@ jobs:
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'ralph') ||
       (github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'ralph')) ||
-      (github.event.action == 'created' && contains(github.event.issue.labels.*.name, 'ralph') && github.event.comment.user.type != 'Bot' && !contains(github.event.comment.body, '<!-- ralph-comment-') && !github.event.issue.pull_request)
+      (github.event.action == 'created' && contains(github.event.issue.labels.*.name, 'ralph') && github.event.comment.user.type != 'Bot' && !contains(github.event.comment.body, '<!-- ralph-comment-') && !github.event.issue.pull_request) ||
+      (github.event_name == 'pull_request_review_comment' && github.event.action == 'created' && github.event.comment.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'ralph/issue-')) ||
+      (github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'ralph/issue-'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: ralph-${{ github.event.issue.number }}
+      group: ralph-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4

--- a/test/helpers/mocks.sh
+++ b/test/helpers/mocks.sh
@@ -188,8 +188,18 @@ case "${1:-}" in
     # Log API calls for test verification
     log_file="${MOCK_GH_API_LOG:-/dev/null}"
     echo "gh $*" >> "${log_file}"
-    # Return a minimal JSON response for reactions
-    echo '{"id":1,"content":"+1"}'
+    # Return appropriate responses based on endpoint
+    endpoint="${2:-}"
+    if [[ "${endpoint}" == *"/pulls/"*"/comments" ]]; then
+      # PR review inline comments — return mock inline comment
+      echo '[{"user":{"login":"reviewer"},"path":"src/main.sh","line":42,"original_line":42,"body":"This function should be refactored for clarity."}]'
+    elif [[ "${endpoint}" == *"/pulls/"*"/reviews" ]]; then
+      # PR reviews — return mock overall review
+      echo '[{"user":{"login":"reviewer"},"state":"CHANGES_REQUESTED","body":"Please address the naming issues and add error handling."}]'
+    else
+      # Return a minimal JSON response for reactions
+      echo '{"id":1,"content":"+1"}'
+    fi
     ;;
   *)
     echo "mock gh: unknown command ${1:-}"

--- a/test/helpers/setup.sh
+++ b/test/helpers/setup.sh
@@ -138,7 +138,90 @@ ${comment_block}
 EOF
 }
 
+# Write a GitHub PR review comment event JSON file
+# Args: $1 = tmpdir to write into
+#       $2 = pr number (default: 999)
+#       $3 = branch name (default: ralph/issue-42)
+#       $4 = issue number embedded in branch (default: 42)
+#       $5 = event action (default: "created")
+create_pr_review_comment_event_json() {
+  local tmpdir="$1"
+  local pr_number="${2:-999}"
+  local branch="${3:-ralph/issue-42}"
+  local event_action="${4:-created}"
+
+  cat > "${tmpdir}/pr-review-comment-event.json" <<EOF
+{
+  "action": "${event_action}",
+  "comment": {
+    "id": 1001,
+    "user": {
+      "login": "reviewer",
+      "type": "User"
+    },
+    "body": "This function should be refactored for clarity.",
+    "path": "src/main.sh",
+    "line": 42,
+    "original_line": 42
+  },
+  "pull_request": {
+    "number": ${pr_number},
+    "title": "feat: implement feature from issue",
+    "body": "Closes #${branch##*-}",
+    "head": {
+      "ref": "${branch}"
+    }
+  },
+  "repository": {
+    "full_name": "test-owner/test-repo",
+    "default_branch": "main"
+  }
+}
+EOF
+}
+
+# Write a GitHub PR review (overall review) event JSON file
+# Args: $1 = tmpdir to write into
+#       $2 = pr number (default: 999)
+#       $3 = branch name (default: ralph/issue-42)
+#       $4 = review state (default: "changes_requested")
+create_pr_review_event_json() {
+  local tmpdir="$1"
+  local pr_number="${2:-999}"
+  local branch="${3:-ralph/issue-42}"
+  local review_state="${4:-changes_requested}"
+
+  cat > "${tmpdir}/pr-review-event.json" <<EOF
+{
+  "action": "submitted",
+  "review": {
+    "id": 2001,
+    "user": {
+      "login": "reviewer",
+      "type": "User"
+    },
+    "body": "Please address the naming issues and add error handling.",
+    "state": "${review_state}"
+  },
+  "pull_request": {
+    "number": ${pr_number},
+    "title": "feat: implement feature from issue",
+    "body": "Closes #${branch##*-}",
+    "head": {
+      "ref": "${branch}"
+    }
+  },
+  "repository": {
+    "full_name": "test-owner/test-repo",
+    "default_branch": "main"
+  }
+}
+EOF
+}
+
 export -f create_test_workspace
 export -f cleanup_test_workspace
 export -f setup_test_env
 export -f create_event_json
+export -f create_pr_review_comment_event_json
+export -f create_pr_review_event_json

--- a/test/integration/test-pr-review-comment.sh
+++ b/test/integration/test-pr-review-comment.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# test-pr-review-comment.sh - Integration test for PR review comment trigger
+#
+# Verifies that the Ralph loop processes a task that includes PR review feedback
+# in task.md (as would be written by entrypoint.sh when triggered by a
+# pull_request_review_comment or pull_request_review event).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/../helpers"
+
+# shellcheck source=test/helpers/setup.sh
+source "${HELPERS_DIR}/setup.sh"
+# shellcheck source=test/helpers/mocks.sh
+source "${HELPERS_DIR}/mocks.sh"
+
+test_pr_review_comment_trigger() {
+  local tmpdir
+  tmpdir="$(create_test_workspace)"
+  local workspace="${tmpdir}/workspace"
+
+  setup_test_env "${tmpdir}"
+  setup_mock_binaries
+
+  # Configure mock: reviewer ships on first iteration
+  export MOCK_REVIEW_DECISION="SHIP"
+
+  cd "${workspace}"
+
+  # Initialize state (normally done by entrypoint.sh)
+  # shellcheck source=scripts/state.sh
+  source "${SCRIPTS_DIR}/state.sh"
+  state_init
+
+  # Write task.md with PR review feedback — this is what entrypoint.sh produces
+  # when triggered by a pull_request_review_comment event
+  local pr_review_context
+  pr_review_context="$(cat <<'EOF'
+# PR Review Feedback (PR #999)
+This run was triggered by a PR review comment on PR #999 (branch: ralph/issue-42). Address all reviewer feedback below.
+
+## Inline Code Comments
+
+### Inline comment by @reviewer on `src/main.sh`:42:
+
+This function should be refactored for clarity.
+
+## Overall Reviews
+
+### Review by @reviewer (CHANGES_REQUESTED):
+
+Please address the naming issues and add error handling.
+EOF
+)"
+
+  state_write_task "Implement feature X" "Add support for feature X as described." "${pr_review_context}"
+  state_write_iteration "0"
+  state_write_issue_number "42"
+  state_write_event_info "created" "1001"
+
+  # Write pr-info.txt as entrypoint.sh would
+  {
+    echo "repo=test-owner/test-repo"
+    echo "branch=ralph/issue-42"
+    echo "issue_title=Implement feature X"
+    echo "merge_strategy=pr"
+    echo "default_branch=main"
+    echo "pr_number=999"
+  } > "${RALPH_DIR}/pr-info.txt"
+
+  # Create and push the ralph branch (simulating prior run that opened the PR)
+  git checkout -b ralph/issue-42 > /dev/null 2>&1
+  git push origin ralph/issue-42 > /dev/null 2>&1
+
+  # Run the real ralph loop
+  export INPUT_MAX_ITERATIONS=5
+  local exit_code=0
+  "${SCRIPTS_DIR}/ralph-loop.sh" || exit_code=$?
+
+  # --- Assertions ---
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo "FAIL: expected exit code 0, got ${exit_code}"
+    teardown_mock_binaries
+    cleanup_test_workspace "${tmpdir}"
+    return 1
+  fi
+
+  if [[ "$(state_read_final_status)" != "SHIPPED" ]]; then
+    echo "FAIL: expected final_status=SHIPPED, got $(state_read_final_status)"
+    teardown_mock_binaries
+    cleanup_test_workspace "${tmpdir}"
+    return 1
+  fi
+
+  if [[ "$(state_read_review_result)" != "SHIP" ]]; then
+    echo "FAIL: expected review_result=SHIP, got $(state_read_review_result)"
+    teardown_mock_binaries
+    cleanup_test_workspace "${tmpdir}"
+    return 1
+  fi
+
+  if [[ "$(state_read_iteration)" != "1" ]]; then
+    echo "FAIL: expected iteration=1, got $(state_read_iteration)"
+    teardown_mock_binaries
+    cleanup_test_workspace "${tmpdir}"
+    return 1
+  fi
+
+  # Verify task.md contains PR review context
+  if ! grep -q "PR Review Feedback" "${RALPH_DIR}/task.md"; then
+    echo "FAIL: task.md should contain PR review feedback section"
+    teardown_mock_binaries
+    cleanup_test_workspace "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "This function should be refactored" "${RALPH_DIR}/task.md"; then
+    echo "FAIL: task.md should contain the inline review comment"
+    teardown_mock_binaries
+    cleanup_test_workspace "${tmpdir}"
+    return 1
+  fi
+
+  if [[ ! -f "worker-output-1.txt" ]]; then
+    echo "FAIL: expected worker-output-1.txt to exist after loop"
+    teardown_mock_binaries
+    cleanup_test_workspace "${tmpdir}"
+    return 1
+  fi
+
+  # Clean up
+  teardown_mock_binaries
+  cleanup_test_workspace "${tmpdir}"
+  echo "PASS: PR review comment trigger runs loop with review context in task.md"
+}
+
+main() {
+  test_pr_review_comment_trigger
+}
+
+main "$@"


### PR DESCRIPTION
## What's changed

Add support for triggering the Ralph loop when a reviewer comments on a Ralph-created pull request. Previously Ralph only responded to issue events; now it also handles `pull_request_review_comment` (inline code comments) and `pull_request_review` (overall reviews submitted on a PR).

When triggered by a PR review event, the entrypoint resolves the original issue number from the branch name (`ralph/issue-NNN`), fetches the issue body via the GitHub API, and appends all inline comments and review bodies to `task.md` under a "PR Review Feedback" section. The worker agent then addresses the reviewer's feedback in the next iteration.

## Why is this important?

The Ralph loop previously had no way to respond to code review feedback on its own PRs. A reviewer leaving comments would need to manually re-trigger the loop via an issue comment. This change closes that gap: any non-bot PR review on a Ralph branch automatically re-runs the loop with full review context, making Ralph a genuine participant in the pull request review cycle.

## Changes

**`entrypoint.sh`**
- Detect PR review events via `GITHUB_EVENT_NAME` (unambiguous — avoids false positives from `pull_request: [labeled]` events that also carry `.pull_request.number`)
- Extract issue number from branch name with regex `ralph/issue-([0-9]+)`
- Fetch issue title/body from GitHub API when triggered by a PR review event
- Fetch all inline review comments (`/pulls/{n}/comments`) and overall reviews (`/pulls/{n}/reviews`) and append them as structured context to `task.md`

**`examples/ralph-workflow.yml` / `.github/workflows/dogfood.yml`**
- Add `pull_request_review: [submitted]` and `pull_request_review_comment: [created]` triggers
- Extend `ralph` job condition to fire for PR review events on `ralph/issue-*` branches, excluding bot authors
- Fix concurrency group to use `github.event.pull_request.number` as fallback when `github.event.issue.number` is absent (PR review events don't carry an issue)

**Tests**
- Update `test/helpers/mocks.sh` mock `gh api` to return realistic JSON for `/pulls/{n}/comments` and `/pulls/{n}/reviews` endpoints
- Add `create_pr_review_comment_event_json` and `create_pr_review_event_json` helpers to `test/helpers/setup.sh`
- Add `test/integration/test-pr-review-comment.sh` verifying the loop runs correctly when `task.md` contains PR review feedback

## Test plan

- [ ] Run `bash test/run-all-tests.sh` — all 12 tests pass
- [ ] Run `docker run --rm -v $(pwd):/mnt koalaman/shellcheck:stable --severity=warning entrypoint.sh scripts/*.sh` — no findings
- [ ] Label an issue with `ralph`, let Ralph open a PR, then post a PR review comment → verify a new run starts and `task.md` contains the review feedback
- [ ] Label a non-ralph PR with `ralph` → verify the `reject-pr` job fires and the ralph job does not run (or exits cleanly)

## Related issues

Closes #70
