### PR TITLE
test: strengthen PR review feedback assertions and add combined test

### DIFF
--- a/test/unit/test-state.sh
+++ b/test/unit/test-state.sh
@@ -503,8 +503,8 @@ test_state_write_task_with_pr_review_feedback() {
     return 1
   fi
 
-  if ! grep -q "Inline comment by @reviewer" .ralph/task.md; then
-    echo "FAIL: task.md should contain inline code comment"
+  if ! grep -q 'Inline comment by @reviewer on `src/main.sh`:42' .ralph/task.md; then
+    echo "FAIL: task.md should contain inline code comment with file path and line number"
     cd - > /dev/null
     rm -rf "${tmpdir}"
     return 1
@@ -534,6 +534,106 @@ test_state_write_task_with_pr_review_feedback() {
   cd - > /dev/null
   rm -rf "${tmpdir}"
   echo "PASS: state_write_task with PR review feedback works correctly"
+}
+
+test_state_write_task_with_comments_and_pr_review_feedback() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cd "${tmpdir}"
+  state_init
+
+  # Simulate both issue comments and PR review feedback present at the same time
+  local issue_comments
+  issue_comments=$'Great idea! Let me work on this.\n---\nWhat about edge cases?'
+
+  local pr_review_context
+  pr_review_context=$'# PR Review Feedback (PR #100)\nThis run was triggered by a PR review comment on PR #100 (branch: ralph/issue-50). Address all reviewer feedback below.\n\n## Inline Code Comments\n\n### Inline comment by @dev on `lib/utils.sh`:15:\n\nThis variable name is too generic.\n\n## Overall Reviews\n\n### Review by @dev (CHANGES_REQUESTED):\n\nPlease rename variables for clarity.'
+
+  local combined_comments
+  combined_comments="${issue_comments}"$'\n\n'"${pr_review_context}"
+
+  state_write_task "Fix naming" "Rename variables in utils." "${combined_comments}"
+
+  if [[ ! -f ".ralph/task.md" ]]; then
+    echo "FAIL: task.md should be created"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "# Fix naming" .ralph/task.md; then
+    echo "FAIL: task.md should contain the issue title"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "Rename variables in utils." .ralph/task.md; then
+    echo "FAIL: task.md should contain the issue body"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "Issue Comments" .ralph/task.md; then
+    echo "FAIL: task.md should contain issue comments section"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "Great idea! Let me work on this." .ralph/task.md; then
+    echo "FAIL: task.md should contain issue comment text"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "What about edge cases?" .ralph/task.md; then
+    echo "FAIL: task.md should contain second issue comment"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "PR Review Feedback (PR #100)" .ralph/task.md; then
+    echo "FAIL: task.md should contain PR review feedback header"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q 'Inline comment by @dev on `lib/utils.sh`:15' .ralph/task.md; then
+    echo "FAIL: task.md should contain inline code comment with file path and line number"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "This variable name is too generic." .ralph/task.md; then
+    echo "FAIL: task.md should contain inline comment body"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "Review by @dev (CHANGES_REQUESTED)" .ralph/task.md; then
+    echo "FAIL: task.md should contain overall review header"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  if ! grep -q "Please rename variables for clarity." .ralph/task.md; then
+    echo "FAIL: task.md should contain overall review body"
+    cd - > /dev/null
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  cd - > /dev/null
+  rm -rf "${tmpdir}"
+  echo "PASS: state_write_task with both issue comments and PR review feedback works correctly"
 }
 
 test_state_write_read_push_error() {
@@ -611,6 +711,7 @@ main() {
   test_state_write_read_event_info_comment || failed=$((failed + 1))
   test_state_read_event_info_default || failed=$((failed + 1))
   test_state_write_task_with_pr_review_feedback || failed=$((failed + 1))
+  test_state_write_task_with_comments_and_pr_review_feedback || failed=$((failed + 1))
   test_state_write_read_push_error || failed=$((failed + 1))
   test_state_read_push_error_default || failed=$((failed + 1))
 


### PR DESCRIPTION
Closes #74

## Summary
- Strengthened inline code comment assertion to validate full header including backticked file path and line number (e.g., `` `src/main.sh`:42 ``), not just the reviewer name substring
- Added new test `test_state_write_task_with_comments_and_pr_review_feedback` verifying both issue comments AND PR review feedback are correctly written to task.md when present simultaneously
- All 18 unit tests pass

## Test plan
- [x] All existing unit tests pass
- [x] New combined test validates both issue comments and PR review feedback coexist correctly
- [x] Inline comment assertion now checks for file path and line number format

**Status:** SHIP (iteration 1)

_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_