### PR TITLE
feat: use a slash command to interact with the ralph loop

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,5 +1,8 @@
 name: Ralph Dogfood
 
+env:
+  RALPH_REVIEW_COMMAND: '/ralph-review'
+
 on:
   issues:
     types: [labeled, edited]
@@ -7,10 +10,6 @@ on:
     types: [created]
   pull_request:
     types: [labeled]
-  pull_request_review:
-    types: [submitted]
-  pull_request_review_comment:
-    types: [created]
 
 permissions:
   contents: write
@@ -41,8 +40,7 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'ralph') ||
       (github.event_name == 'issues' && github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'ralph')) ||
       (github.event_name == 'issue_comment' && github.event.action == 'created' && contains(github.event.issue.labels.*.name, 'ralph') && github.event.comment.user.type != 'Bot' && !contains(github.event.comment.body, '<!-- ralph-comment-') && !github.event.issue.pull_request) ||
-      (github.event_name == 'pull_request_review_comment' && github.event.action == 'created' && github.event.comment.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'ralph/issue-')) ||
-      (github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'ralph/issue-'))
+      (github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.pull_request && (github.event.comment.body == env.RALPH_REVIEW_COMMAND || startsWith(github.event.comment.body, format('{0} ', env.RALPH_REVIEW_COMMAND))) && github.event.comment.user.type != 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
@@ -67,6 +65,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GH_PAT_TOKEN }}
+          ralph_review_command: ${{ env.RALPH_REVIEW_COMMAND }}
           reviewer_model: opus
           reviewer_tone: |
             You are C-3PO, the protocol droid from Star Wars. Embody these characteristics:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ When you label an issue, Ralph:
 ```yaml
 name: Ralph Loop
 
+env:
+  RALPH_REVIEW_COMMAND: '/ralph-review'
+
 on:
   issues:
     types: [labeled, edited]
@@ -42,19 +45,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
+          existing="$(gh pr view "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
-            --body "🤖 **Ralph** can only work on issues, not pull requests. Please create an issue and label it with \`ralph\` instead."
+            --json comments --jq '.comments[].body' \
+            | grep -c '🤖 \*\*Ralph\*\*' || true)"
+          if [[ "${existing}" -eq 0 ]]; then
+            gh pr comment "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" \
+              --body "🤖 **Ralph** can only work on issues, not pull requests. Please create an issue and label it with \`ralph\` instead."
+          fi
 
   ralph:
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'ralph') ||
-      (github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'ralph')) ||
-      (github.event.action == 'created' && contains(github.event.issue.labels.*.name, 'ralph') && github.event.comment.user.type != 'Bot' && !contains(github.event.comment.body, '<!-- ralph-comment-') && !github.event.issue.pull_request)
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'ralph') ||
+      (github.event_name == 'issues' && github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'ralph')) ||
+      (github.event_name == 'issue_comment' && github.event.action == 'created' && contains(github.event.issue.labels.*.name, 'ralph') && github.event.comment.user.type != 'Bot' && !contains(github.event.comment.body, '<!-- ralph-comment-') && !github.event.issue.pull_request) ||
+      (github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.pull_request && (github.event.comment.body == env.RALPH_REVIEW_COMMAND || startsWith(github.event.comment.body, format('{0} ', env.RALPH_REVIEW_COMMAND))) && github.event.comment.user.type != 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
-      group: ralph-${{ github.event.issue.number }}
+      group: ralph-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +72,7 @@ jobs:
       - uses: mdelapenya/claude-ralph-github-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          ralph_review_command: ${{ env.RALPH_REVIEW_COMMAND }}
 ```
 
 3. Create a `ralph` label in your repository
@@ -86,6 +97,7 @@ jobs:
 | `default_branch` | No | — | Default branch to merge into when using `squash-merge` strategy (auto-detected from repo if not specified) |
 | `worker_tone` | No | — | Personality/tone for the worker agent (e.g., "pirate", "formal", "enthusiastic"). If set, the worker will respond with this personality |
 | `reviewer_tone` | No | — | Personality/tone for the reviewer agent (e.g., "pirate", "formal", "enthusiastic"). If set, the reviewer will respond with this personality |
+| `ralph_review_command` | No | `/ralph-review` | Slash command to trigger a re-review run on a Ralph-created PR (e.g., `/ralph-review focus on tests`) |
 
 ## Outputs
 
@@ -126,10 +138,11 @@ If a PR already exists (on re-runs), the reviewer updates the title directly via
 
 ### Triggers and Re-runs
 
-Ralph triggers in three ways:
+Ralph triggers in four ways:
 - **Label added:** When the `ralph` label is added to an issue (first run or re-trigger by removing and re-adding the label).
 - **Issue edited:** When an issue that already has the `ralph` label is edited (title or body changed). This lets you refine requirements and have Ralph re-process the updated task.
 - **Comment added:** When a new comment is posted on an issue that has the `ralph` label. This enables a conversational workflow where you can give Ralph follow-up instructions via comments. Ralph's own comments (identified by `<!-- ralph-comment-* -->` markers) do not retrigger the workflow. This works with the standard `GITHUB_TOKEN` — no PAT is required.
+- **`/ralph-review` on a Ralph PR:** When you post `/ralph-review` as a comment on a Ralph-created pull request, Ralph re-runs the loop incorporating all PR review feedback. See [PR Review Workflow](#pr-review-workflow) below.
 
 In all cases, Ralph detects the existing branch if one exists, checks it out, and continues from where it left off. The worker re-reads the task from the issue (which may have changed) and the branch's commit history to understand what was already done. New commits are added on top — Ralph never force-pushes.
 
@@ -208,6 +221,41 @@ If you need Ralph to edit workflow files, use a Personal Access Token (PAT) with
 
 **With a PAT (workflow scope):** Ralph can modify any file including workflows. Use this when tasks specifically require workflow changes.
 
+### PR Review Workflow
+
+Once Ralph opens a pull request, you can close the feedback loop without leaving GitHub:
+
+1. Review the PR normally — leave inline comments, an overall review, or both
+2. Post `/ralph-review` as a **comment on the PR** to trigger another Ralph run
+3. Ralph re-runs the full loop, incorporating all review feedback into the task context:
+   - Inline code comments (file, line, and body)
+   - Overall review bodies and their state (e.g., `CHANGES_REQUESTED`)
+4. Ralph commits the fixes and pushes to the same branch, updating the PR automatically
+
+**Passing reviewer instructions:** You can add extra guidance after the command. Everything after `/ralph-review` (separated by a space or newline) is passed to the worker as "Reviewer Instructions":
+
+```
+/ralph-review focus on error handling and add unit tests for the new functions
+```
+
+**Slash command constant:** Define the command string once at the workflow level so the job condition and the action input stay in sync:
+
+```yaml
+env:
+  RALPH_REVIEW_COMMAND: '/ralph-review'
+
+# In the job condition:
+(github.event_name == 'issue_comment' && github.event.issue.pull_request && \
+  (github.event.comment.body == env.RALPH_REVIEW_COMMAND || \
+   startsWith(github.event.comment.body, format('{0} ', env.RALPH_REVIEW_COMMAND))) && \
+  github.event.comment.user.type != 'Bot')
+
+# In the action step:
+ralph_review_command: ${{ env.RALPH_REVIEW_COMMAND }}
+```
+
+**Note:** Only non-bot users can trigger `/ralph-review`. Ralph's own comments are never used as triggers.
+
 ### Pull requests
 
 Ralph only works on **issues**. If the `ralph` label is added to a pull request, Ralph will post a comment explaining it can only work on issues, and exit without making changes.
@@ -263,6 +311,7 @@ shellcheck --severity=warning entrypoint.sh scripts/*.sh test/**/*.sh test/*.sh
 | | `test/integration/test-max-iterations.sh` | REVISE loop exhausts `INPUT_MAX_ITERATIONS`, exits with code 2 |
 | | `test/integration/test-error-handling.sh` | Worker failure triggers ERROR exit with code 1 |
 | | `test/integration/test-squash-merge.sh` | Squash-merge strategy writes `merge-commit.txt` instead of PR URL |
+| | `test/integration/test-pr-review-comment.sh` | `/ralph-review` slash command runs loop with PR review context in `task.md` |
 
 ### How Integration Tests Work
 

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,10 @@ inputs:
     description: 'Personality/tone for the reviewer agent (e.g., "pirate", "formal", "enthusiastic"). If set, the reviewer will respond with this personality.'
     required: false
     default: ''
+  ralph_review_command:
+    description: 'Slash command to trigger a re-review on a Ralph PR (e.g., "/ralph-review focus on tests")'
+    required: false
+    default: '/ralph-review'
 
 outputs:
   pr_url:
@@ -94,3 +98,4 @@ runs:
     INPUT_DEFAULT_BRANCH: ${{ inputs.default_branch }}
     INPUT_WORKER_TONE: ${{ inputs.worker_tone }}
     INPUT_REVIEWER_TONE: ${{ inputs.reviewer_tone }}
+    INPUT_RALPH_REVIEW_COMMAND: ${{ inputs.ralph_review_command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,29 +55,47 @@ if ! command -v jq &> /dev/null; then
   exit 1
 fi
 
-# Detect whether this is a PR review event or a regular issue event.
-# Use GITHUB_EVENT_NAME (set by GitHub Actions) for unambiguous detection.
-# Checking .pull_request.number would be ambiguous because pull_request: [labeled]
-# events also carry that field.
+# Detect whether this is a /ralph-review slash command on a PR comment.
+# PR comments come through the issue_comment event with .issue.pull_request set.
+# The slash command avoids triggering on every review event and gives the user
+# explicit control over when to re-run the loop.
 PR_REVIEW_EVENT=false
 PR_NUMBER=""
 PR_BRANCH=""
 TEMP_ISSUE_NUMBER=""
-if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request_review_comment" || \
-      "${GITHUB_EVENT_NAME:-}" == "pull_request_review" ]]; then
-  PR_REVIEW_EVENT=true
-  PR_NUMBER="$(jq -r '.pull_request.number' "${GITHUB_EVENT_PATH}")"
-  PR_BRANCH="$(jq -r '.pull_request.head.ref // ""' "${GITHUB_EVENT_PATH}")"
-  # Extract issue number from the ralph branch name (pattern: ralph/issue-NNN)
-  if [[ "${PR_BRANCH}" =~ ralph/issue-([0-9]+) ]]; then
-    TEMP_ISSUE_NUMBER="${BASH_REMATCH[1]}"
+RALPH_REVIEW_CMD="${INPUT_RALPH_REVIEW_COMMAND:-/ralph-review}"
+RALPH_REVIEW_ARGS=""
+if [[ "${GITHUB_EVENT_NAME:-}" == "issue_comment" ]]; then
+  COMMENT_BODY="$(jq -r '.comment.body // ""' "${GITHUB_EVENT_PATH}")"
+  IS_PR_COMMENT="$(jq -r '.issue.pull_request // empty' "${GITHUB_EVENT_PATH}")"
+  # Match exact command, command + space args, or command + newline args.
+  # A bare prefix match (e.g. == "*") would accept "/ralph-review2" as valid.
+  if [[ -n "${IS_PR_COMMENT}" ]] && \
+     [[ "${COMMENT_BODY}" == "${RALPH_REVIEW_CMD}" || \
+        "${COMMENT_BODY}" == "${RALPH_REVIEW_CMD} "* || \
+        "${COMMENT_BODY}" == "${RALPH_REVIEW_CMD}"$'\n'* ]]; then
+    PR_REVIEW_EVENT=true
+    PR_NUMBER="$(jq -r '.issue.number' "${GITHUB_EVENT_PATH}")"
+    PR_BRANCH="$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")"
+    # Extract optional arguments after the command (space or newline separator)
+    if [[ "${COMMENT_BODY}" == "${RALPH_REVIEW_CMD} "* ]]; then
+      RALPH_REVIEW_ARGS="${COMMENT_BODY#"${RALPH_REVIEW_CMD} "}"
+    elif [[ "${COMMENT_BODY}" == "${RALPH_REVIEW_CMD}"$'\n'* ]]; then
+      RALPH_REVIEW_ARGS="${COMMENT_BODY#"${RALPH_REVIEW_CMD}"$'\n'}"
+    fi
+    # Extract issue number from the ralph branch name (pattern: ralph/issue-NNN)
+    if [[ "${PR_BRANCH}" =~ ralph/issue-([0-9]+) ]]; then
+      TEMP_ISSUE_NUMBER="${BASH_REMATCH[1]}"
+    fi
+    if [[ -z "${TEMP_ISSUE_NUMBER}" ]]; then
+      echo "❌ Error: Cannot determine issue number from PR branch: ${PR_BRANCH}"
+      echo "   Fix: The PR branch must follow the pattern 'ralph/issue-NNN'"
+      exit 1
+    fi
   fi
-  if [[ -z "${TEMP_ISSUE_NUMBER}" ]]; then
-    echo "❌ Error: Cannot determine issue number from PR branch: ${PR_BRANCH}"
-    echo "   Fix: The PR branch must follow the pattern 'ralph/issue-NNN'"
-    exit 1
-  fi
-else
+fi
+
+if [[ "${PR_REVIEW_EVENT}" == "false" ]]; then
   TEMP_ISSUE_NUMBER="$(jq -r '.issue.number // empty' "${GITHUB_EVENT_PATH}" 2>/dev/null || echo "")"
   if [[ -z "${TEMP_ISSUE_NUMBER}" ]]; then
     echo "❌ Error: Event file does not contain a valid issue number"
@@ -142,9 +160,12 @@ if [[ "${PR_REVIEW_EVENT}" == "true" ]] && command -v gh &> /dev/null; then
   PR_REVIEWS="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
     --jq '.[] | select(.body != null and .body != "") | "### Review by @\(.user.login) (\(.state)):\n\n\(.body)\n"' \
     2>/dev/null || echo "")"
-  if [[ -n "${PR_INLINE_COMMENTS}" || -n "${PR_REVIEWS}" ]]; then
+  if [[ -n "${PR_INLINE_COMMENTS}" || -n "${PR_REVIEWS}" || -n "${RALPH_REVIEW_ARGS}" ]]; then
     PR_REVIEW_CONTEXT="# PR Review Feedback (PR #${PR_NUMBER})"$'\n'
-    PR_REVIEW_CONTEXT+="This run was triggered by a PR review comment on PR #${PR_NUMBER} (branch: ${PR_BRANCH}). Address all reviewer feedback below."$'\n'
+    PR_REVIEW_CONTEXT+="This run was triggered by the ${RALPH_REVIEW_CMD} slash command on PR #${PR_NUMBER} (branch: ${PR_BRANCH})."$'\n'
+    if [[ -n "${RALPH_REVIEW_ARGS}" ]]; then
+      PR_REVIEW_CONTEXT+=$'\n## Reviewer Instructions\n\n'"${RALPH_REVIEW_ARGS}"$'\n'
+    fi
     if [[ -n "${PR_INLINE_COMMENTS}" ]]; then
       PR_REVIEW_CONTEXT+=$'\n## Inline Code Comments\n\n'"${PR_INLINE_COMMENTS}"
     fi

--- a/examples/ralph-workflow.yml
+++ b/examples/ralph-workflow.yml
@@ -1,5 +1,8 @@
 name: Ralph Loop
 
+env:
+  RALPH_REVIEW_COMMAND: '/ralph-review'
+
 on:
   issues:
     types: [labeled, edited]
@@ -7,10 +10,6 @@ on:
     types: [created]
   pull_request:
     types: [labeled]
-  pull_request_review:
-    types: [submitted]
-  pull_request_review_comment:
-    types: [created]
 
 permissions:
   contents: write
@@ -41,8 +40,7 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'ralph') ||
       (github.event_name == 'issues' && github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'ralph')) ||
       (github.event_name == 'issue_comment' && github.event.action == 'created' && contains(github.event.issue.labels.*.name, 'ralph') && github.event.comment.user.type != 'Bot' && !contains(github.event.comment.body, '<!-- ralph-comment-') && !github.event.issue.pull_request) ||
-      (github.event_name == 'pull_request_review_comment' && github.event.action == 'created' && github.event.comment.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'ralph/issue-')) ||
-      (github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.user.type != 'Bot' && startsWith(github.event.pull_request.head.ref, 'ralph/issue-'))
+      (github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.pull_request && (github.event.comment.body == env.RALPH_REVIEW_COMMAND || startsWith(github.event.comment.body, format('{0} ', env.RALPH_REVIEW_COMMAND))) && github.event.comment.user.type != 'Bot')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency:
@@ -54,6 +52,7 @@ jobs:
       - uses: mdelapenya/claude-ralph-github-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          ralph_review_command: ${{ env.RALPH_REVIEW_COMMAND }}
           # Optional: use a PAT with the `workflow` scope to allow Ralph
           # to modify files in .github/workflows/. The default GITHUB_TOKEN
           # cannot push workflow changes regardless of permissions settings.

--- a/test/helpers/mocks.sh
+++ b/test/helpers/mocks.sh
@@ -155,6 +155,10 @@ case "${1:-}" in
       edit)
         echo "PR updated"
         ;;
+      view)
+        # Return the ralph branch name for /ralph-review slash command flow
+        echo "ralph/issue-42"
+        ;;
       *)
         echo "mock gh pr: unknown subcommand ${2:-}"
         ;;

--- a/test/helpers/setup.sh
+++ b/test/helpers/setup.sh
@@ -138,77 +138,35 @@ ${comment_block}
 EOF
 }
 
-# Write a GitHub PR review comment event JSON file
+# Write a GitHub issue_comment event JSON for a /ralph-review slash command on a PR.
+# This is the event produced when a user types "/ralph-review" as a PR comment.
+# PR comments go through the issue_comment event with .issue.pull_request set.
 # Args: $1 = tmpdir to write into
 #       $2 = pr number (default: 999)
-#       $3 = branch name (default: ralph/issue-42)
-#       $4 = issue number embedded in branch (default: 42)
-#       $5 = event action (default: "created")
-create_pr_review_comment_event_json() {
+#       $3 = issue number (default: 42)
+#       $4 = command body (default: "/ralph-review")
+create_ralph_review_slash_command_event_json() {
   local tmpdir="$1"
   local pr_number="${2:-999}"
-  local branch="${3:-ralph/issue-42}"
-  local event_action="${4:-created}"
+  local issue_number="${3:-42}"
+  local command_body="${4:-/ralph-review}"
 
-  cat > "${tmpdir}/pr-review-comment-event.json" <<EOF
+  cat > "${tmpdir}/ralph-review-event.json" <<EOF
 {
-  "action": "${event_action}",
+  "action": "created",
   "comment": {
     "id": 1001,
     "user": {
       "login": "reviewer",
       "type": "User"
     },
-    "body": "This function should be refactored for clarity.",
-    "path": "src/main.sh",
-    "line": 42,
-    "original_line": 42
+    "body": "${command_body}"
   },
-  "pull_request": {
+  "issue": {
     "number": ${pr_number},
-    "title": "feat: implement feature from issue",
-    "body": "Closes #${branch##*-}",
-    "head": {
-      "ref": "${branch}"
-    }
-  },
-  "repository": {
-    "full_name": "test-owner/test-repo",
-    "default_branch": "main"
-  }
-}
-EOF
-}
-
-# Write a GitHub PR review (overall review) event JSON file
-# Args: $1 = tmpdir to write into
-#       $2 = pr number (default: 999)
-#       $3 = branch name (default: ralph/issue-42)
-#       $4 = review state (default: "changes_requested")
-create_pr_review_event_json() {
-  local tmpdir="$1"
-  local pr_number="${2:-999}"
-  local branch="${3:-ralph/issue-42}"
-  local review_state="${4:-changes_requested}"
-
-  cat > "${tmpdir}/pr-review-event.json" <<EOF
-{
-  "action": "submitted",
-  "review": {
-    "id": 2001,
-    "user": {
-      "login": "reviewer",
-      "type": "User"
-    },
-    "body": "Please address the naming issues and add error handling.",
-    "state": "${review_state}"
-  },
-  "pull_request": {
-    "number": ${pr_number},
-    "title": "feat: implement feature from issue",
-    "body": "Closes #${branch##*-}",
-    "head": {
-      "ref": "${branch}"
+    "pull_request": {
+      "url": "https://api.github.com/repos/test-owner/test-repo/pulls/${pr_number}",
+      "html_url": "https://github.com/test-owner/test-repo/pull/${pr_number}"
     }
   },
   "repository": {
@@ -223,5 +181,4 @@ export -f create_test_workspace
 export -f cleanup_test_workspace
 export -f setup_test_env
 export -f create_event_json
-export -f create_pr_review_comment_event_json
-export -f create_pr_review_event_json
+export -f create_ralph_review_slash_command_event_json

--- a/test/integration/test-pr-review-comment.sh
+++ b/test/integration/test-pr-review-comment.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# test-pr-review-comment.sh - Integration test for PR review comment trigger
+# test-pr-review-comment.sh - Integration test for /ralph-review slash command
 #
 # Verifies that the Ralph loop processes a task that includes PR review feedback
 # in task.md (as would be written by entrypoint.sh when triggered by a
-# pull_request_review_comment or pull_request_review event).
+# /ralph-review comment on a Ralph-created PR).
 
 set -euo pipefail
 
@@ -15,7 +15,7 @@ source "${HELPERS_DIR}/setup.sh"
 # shellcheck source=test/helpers/mocks.sh
 source "${HELPERS_DIR}/mocks.sh"
 
-test_pr_review_comment_trigger() {
+test_ralph_review_slash_command() {
   local tmpdir
   tmpdir="$(create_test_workspace)"
   local workspace="${tmpdir}/workspace"
@@ -34,11 +34,11 @@ test_pr_review_comment_trigger() {
   state_init
 
   # Write task.md with PR review feedback — this is what entrypoint.sh produces
-  # when triggered by a pull_request_review_comment event
+  # when triggered by a /ralph-review slash command on a Ralph PR
   local pr_review_context
   pr_review_context="$(cat <<'EOF'
 # PR Review Feedback (PR #999)
-This run was triggered by a PR review comment on PR #999 (branch: ralph/issue-42). Address all reviewer feedback below.
+This run was triggered by a /ralph-review slash command on PR #999 (branch: ralph/issue-42). Address all reviewer feedback below.
 
 ## Inline Code Comments
 
@@ -115,8 +115,8 @@ EOF
     return 1
   fi
 
-  if ! grep -q "This function should be refactored" "${RALPH_DIR}/task.md"; then
-    echo "FAIL: task.md should contain the inline review comment"
+  if ! grep -q "ralph-review" "${RALPH_DIR}/task.md"; then
+    echo "FAIL: task.md should mention the /ralph-review slash command"
     teardown_mock_binaries
     cleanup_test_workspace "${tmpdir}"
     return 1
@@ -132,11 +132,11 @@ EOF
   # Clean up
   teardown_mock_binaries
   cleanup_test_workspace "${tmpdir}"
-  echo "PASS: PR review comment trigger runs loop with review context in task.md"
+  echo "PASS: /ralph-review slash command runs loop with review context in task.md"
 }
 
 main() {
-  test_pr_review_comment_trigger
+  test_ralph_review_slash_command
 }
 
 main "$@"


### PR DESCRIPTION
## What's changed

Replaces automatic PR review event triggers (`pull_request_review`, `pull_request_review_comment`) with an explicit `/ralph-review` slash command. Users post the command as a comment on a Ralph-created PR to trigger a re-run; everything after the command is passed to the worker as reviewer instructions (e.g., `/ralph-review focus on error handling`).

Also fixes a bug where bare `github.event.action` checks in the job `if` condition matched across all event types, causing the `ralph` job to fire on `pull_request: [labeled]` events and fail with a cryptic "no issue number" error. Each clause now carries an explicit `github.event_name` guard.

## Why is this important?

The automatic PR review triggers fired on every review comment, creating noise on every CI run. The slash command gives users explicit control: Ralph only re-runs when asked, keeping CI quiet between human review rounds.

The `event_name` scoping fix eliminates a confusing failure mode: labeling a non-Ralph PR with `ralph` now correctly fires only `reject-pr` (which posts the "please create an issue" comment) — the `ralph` job is simply skipped.

## Changes

**Slash command trigger (`/ralph-review`)**
- `entrypoint.sh`: detects `issue_comment` events on PRs where the body matches the command (exact or with space-separated args); extracts issue number from `ralph/issue-NNN` branch name; fetches inline PR comments and overall review bodies; appends as "PR Review Feedback" section in `task.md`; optional args become a "Reviewer Instructions" subsection
- `action.yml`: adds `ralph_review_command` input (default `/ralph-review`) and passes it as `INPUT_RALPH_REVIEW_COMMAND`
- `dogfood.yml` / `examples/ralph-workflow.yml`: adds workflow-level `RALPH_REVIEW_COMMAND` env constant; removes `pull_request_review*` triggers; adds `/ralph-review` clause to job condition using `format('{0} ', env.RALPH_REVIEW_COMMAND)` to prevent prefix false-positives; passes `ralph_review_command` to the action

**Event-name scoping fix**
- All job `if` clauses now prefix with `github.event_name == 'issues'` or `github.event_name == 'issue_comment'` — applied to both workflow files
- Concurrency group updated to `ralph-${{ github.event.issue.number || github.event.pull_request.number }}` to cover PR comment events

**`reject-pr` deduplication**
- `reject-pr` step now checks for an existing Ralph comment before posting, preventing duplicate "please create an issue" comments on repeated label/unlabel cycles

**Tests**
- `test/helpers/setup.sh`: replaces `create_pr_review_comment_event_json` / `create_pr_review_event_json` with `create_ralph_review_slash_command_event_json`
- `test/helpers/mocks.sh`: adds `gh pr view` mock returning `ralph/issue-42`; adds endpoint-aware `gh api` responses for `/pulls/N/comments` and `/pulls/N/reviews`
- `test/integration/test-pr-review-comment.sh`: updated to exercise the slash command flow end-to-end

**README**
- Quick Start snippet updated to the new workflow shape
- Adds `ralph_review_command` to the inputs table
- New "PR Review Workflow" section documenting the slash command pattern

## Test plan

- [ ] Post `/ralph-review` on a Ralph PR → Ralph re-runs and incorporates PR review comments
- [ ] Post `/ralph-review focus on tests` → "focus on tests" appears as Reviewer Instructions in `task.md`
- [ ] Label a non-Ralph PR with `ralph` → only `reject-pr` fires, `ralph` is skipped
- [ ] Label an issue with `ralph` → `ralph` fires as normal
- [ ] `bash test/run-all-tests.sh` passes, including `test-pr-review-comment.sh`

## Related issues

Closes #70
