### PR TITLE
fix: resolve gh pr view for PR's head branch in the context of a slash command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,7 +85,7 @@ if [[ "${GITHUB_EVENT_NAME:-}" == "issue_comment" ]]; then
       else
         GH_ERR_MSG="$(cat "${GH_PR_ERR}" 2>/dev/null || true)"
         echo "   gh error: ${GH_ERR_MSG:-<no output>}"
-        echo "   Fix: Ensure the token has pull-requests:read scope for ${GITHUB_REPOSITORY}"
+        echo "   Fix: Ensure the workflow has 'pull-requests: read' permission (or 'repo' scope if using a PAT) for ${GITHUB_REPOSITORY}"
       fi
       rm -f "${GH_PR_ERR}"
       exit 1


### PR DESCRIPTION
## What's changed

When a `/ralph-review` slash command is posted on a PR comment, the action calls `gh pr view` to resolve the PR's head branch and extract the linked issue number. Previously, stderr was suppressed with `2>/dev/null` and failure silently produced an empty `PR_BRANCH`, causing a misleading error: _"The PR branch must follow the pattern 'ralph/issue-NNN'"_ — even when the branch name was perfectly valid.

This fix captures `gh` stderr to a temp file instead of discarding it, checks for an empty result immediately after the call, and emits a targeted error message that distinguishes between a missing `GH_TOKEN` and other `gh` failures (printing the actual `gh` error output in the latter case).

## Why is this important?

The previous error message sent users chasing a non-existent branch naming problem when the real issue was a `gh` authentication or permission failure. With this fix, operators get actionable diagnostics — either a prompt to set `GH_TOKEN` or the verbatim error from `gh` — so they can resolve the underlying cause quickly.

## Changes

**`entrypoint.sh`**
- Replace `gh pr view … 2>/dev/null || echo ""` with stderr capture via `mktemp` temp file
- Add an early-exit block when `PR_BRANCH` is empty: check `GH_TOKEN`, print captured `gh` error, exit with a clear message
- Preserve the original "branch must follow pattern" error for the case where `gh` succeeds but returns a non-Ralph branch

## Test plan
- [ ] Trigger `/ralph-review` on a Ralph PR with a valid `GH_TOKEN` — should proceed normally
- [ ] Trigger with `GH_TOKEN` unset — should print `GH_TOKEN is not set` error and exit 1
- [ ] Trigger with an invalid/expired token — should print the `gh` error output and exit 1
- [ ] Trigger on a PR whose branch does _not_ follow `ralph/issue-NNN` — should still print the branch pattern error
