### PR TITLE
feat: always log claude output in json format

### DIFF
--- a/scripts/reviewer.sh
+++ b/scripts/reviewer.sh
@@ -64,6 +64,7 @@ fi
 cli_args=(
   -p
   --model "${REVIEWER_MODEL}"
+  --output-format json
   --allowedTools "${REVIEWER_TOOLS}"
   --append-system-prompt "${system_prompt}"
 )
@@ -75,8 +76,13 @@ if [[ "${RALPH_VERBOSE:-false}" == "true" ]]; then
 fi
 
 # Invoke Claude CLI in print mode with the reviewer system prompt
+# Always capture and log the JSON output
 reviewer_exit=0
-claude "${cli_args[@]}" "${prompt}" || reviewer_exit=$?
+reviewer_output=""
+reviewer_output="$(claude "${cli_args[@]}" "${prompt}" 2>&1)" || reviewer_exit=$?
+
+echo "${reviewer_output}"
+echo "${reviewer_output}" > "${RALPH_DIR}/reviewer-output.json"
 
 if [[ ${reviewer_exit} -ne 0 ]]; then
   echo "ERROR: Reviewer Claude CLI exited with code ${reviewer_exit}"

--- a/scripts/security-gate.sh
+++ b/scripts/security-gate.sh
@@ -64,6 +64,7 @@ fi
 cli_args=(
   -p
   --model "${SECURITY_GATE_MODEL}"
+  --output-format json
   --allowedTools "${SECURITY_GATE_TOOLS}"
   --append-system-prompt "${system_prompt}"
 )
@@ -75,8 +76,13 @@ if [[ "${RALPH_VERBOSE:-false}" == "true" ]]; then
 fi
 
 # Invoke Claude CLI in print mode with the security gate system prompt
+# Always capture and log the JSON output
 gate_exit=0
-claude "${cli_args[@]}" "${prompt}" || gate_exit=$?
+gate_output=""
+gate_output="$(claude "${cli_args[@]}" "${prompt}" 2>&1)" || gate_exit=$?
+
+echo "${gate_output}"
+echo "${gate_output}" > "${RALPH_DIR}/security-gate-output.json"
 
 if [[ ${gate_exit} -ne 0 ]]; then
   echo "ERROR: Security gate Claude CLI exited with code ${gate_exit}"

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -76,6 +76,7 @@ fi
 cli_args=(
   -p
   --model "${WORKER_MODEL}"
+  --output-format json
   --allowedTools "${ALLOWED_TOOLS}"
   --append-system-prompt "${system_prompt}"
 )
@@ -87,8 +88,13 @@ if [[ "${RALPH_VERBOSE:-false}" == "true" ]]; then
 fi
 
 # Invoke Claude CLI in print mode with the worker system prompt
+# Always capture and log the JSON output
 worker_exit=0
-claude "${cli_args[@]}" "${prompt}" || worker_exit=$?
+worker_output=""
+worker_output="$(claude "${cli_args[@]}" "${prompt}" 2>&1)" || worker_exit=$?
+
+echo "${worker_output}"
+echo "${worker_output}" > "${RALPH_DIR}/worker-output.json"
 
 if [[ ${worker_exit} -ne 0 ]]; then
   echo "ERROR: Worker Claude CLI exited with code ${worker_exit}"


### PR DESCRIPTION
Closes #91

**Status:** SHIP (iteration 1)

## Summary

- Added `--output-format json` flag to all Claude CLI invocations across `worker.sh`, `reviewer.sh`, and `security-gate.sh`
- Captured CLI output into variables and saved to `.ralph/*.json` files (`worker-output.json`, `reviewer-output.json`, `security-gate-output.json`)
- Output is still echoed to stdout for GitHub Actions log visibility
- No downstream breakage: decisions (SHIP/REVISE, PASS/FAIL) are written to state files by agents via tools, not parsed from stdout

All 17 tests pass.

---
_Generated by [Claude Ralph GitHub Action](https://github.com/mdelapenya/claude-ralph-github-action)_